### PR TITLE
Fix dup-src with 0compile.properties

### DIFF
--- a/build.py
+++ b/build.py
@@ -647,11 +647,11 @@ def dup_src(fn):
 		reldir = root[len(srcdir):]
 
 		if '.git' in dirs:
-			print "dup-src: skipping", reldir
+			print "dup-src: skipping %s" % (os.path.join(reldir, '.git'))
 			dirs.remove('.git')
 
 		if (reldir == 'build' and build_in_src) or \
-				('0compile.properties' in files and not build_in_src):
+				('0compile.properties' in files and not build_in_src and reldir != ""):
 			print "dup-src: skipping", reldir
 			dirs[:] = []
 			continue


### PR DESCRIPTION
This was intended to avoid copying sub-directories that are being used as build directories. However, if the source code has a 0compile.properties at its top level, it also skipped copying everything.

Also, improve the message shown when skipping `.git` (before, it only showed the directory, which was typically the empty string anyway).