### PR TITLE
Improve output when used with 0repo

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -68,9 +68,13 @@ def do_publish(args):
 	if options.target_feed is None:
 		# If --target-feed is used this is probably a script, so don't print
 		# out hints.
-		print "Now upload '%s' as:\n%s\n" % (archive_name, download_url)
-
-		print "Once uploaded, you can download and run with:"
-		print "$ 0launch %s" % target_feed
+		if download_base_url:
+			print "Now upload '%s' as:\n%s\n" % (archive_name, download_url)
+			print "Once uploaded, you can download and run with:"
+			print "0launch %s" % target_feed
+		else:
+			print "Generated archive '%s' and feed '%s'." % (archive_name, target_feed)
+			print "Upload it to a repository with:"
+			print "0repo add %s" % target_feed
 
 __main__.commands.append(do_publish)


### PR DESCRIPTION
Running `0compile publish` without a URL (for use with `0repo`) previously said e.g.

    Now upload 'gnu-hello-linux-x86_64-1.3.tar.bz2' as:
    gnu-hello-linux-x86_64-1.3.tar.bz2

Now it says:

    Generated archive 'gnu-hello-linux-x86_64-1.3.tar.bz2' and feed 'GNU-Hello-1.3.xml'.
    Upload it to a repository with:
    0repo add GNU-Hello-1.3.xml